### PR TITLE
docs(build): standardize project on cmake with ninja

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure CMake
-        run: cmake -S . -B build
+        run: cmake -S . -B build -G Ninja -DCMAKE_C_COMPILER=gcc
 
       - name: Build
-        run: cmake --build build --config Release
+        run: cmake --build build
 
       #- name: Run tests
         # run: ctest --test-dir build --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@ project(REB
     DESCRIPTION "Remote Engine Blocker"
     LANGUAGES C)
 
+if(NOT CMAKE_GENERATOR STREQUAL "Ninja")
+    message(WARNING "This project is standardized on the Ninja generator.")
+    message(WARNING "Please configure using: cmake -S . -B build -G Ninja -DCMAKE_C_COMPILER=gcc")
+endif()
+
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)

--- a/README.md
+++ b/README.md
@@ -19,9 +19,42 @@ This repository contains:
 - `docs/` → architecture, RTM, decisions, and test plan
 - `.github/` → CI and contribution templates
 
-## Build
+## Build environment
 
-Instructions will be added as the build system is finalized.
+This project is standardized on:
+
+- GCC as the C compiler
+- CMake as the build system generator
+- Ninja as the build backend
+
+### Required tools
+
+- GCC
+- CMake
+- Ninja
+- Python 3.x
+
+### Windows setup
+
+Check WinGet:
+```powershell
+winget --version
+```
+Check the compiler and build tools:
+```powershell
+gcc --version
+cmake --version
+ninja --version
+```
+If one of these is not properly installed, the build will not work. Otherwise, go to the next step.
+
+### Configure and build
+In the repository root `` remote-engine-blocker/`` run the following commands:
+
+```powershell
+cmake -S . -B build -G Ninja -DCMAKE_C_COMPILER=gcc
+cmake --build build
+```
 
 ## Run
 

--- a/docs/design/team_workflow.md
+++ b/docs/design/team_workflow.md
@@ -23,3 +23,24 @@ Use Conventional Commits:
 - PRs target `dev`
 - at least one peer review
 - build must pass before merge
+
+## Build standard
+
+All developers must use the same local build configuration.
+
+### Official toolchain
+
+- GCC
+- CMake
+- Ninja
+
+### Official configure command
+
+```powershell
+cmake -S . -B build -G Ninja -DCMAKE_C_COMPILER=gcc
+```
+
+### Official configure command
+```powershell
+cmake --build build
+```


### PR DESCRIPTION
## Summary

This PR standardizes the project build environment across all team members.

The project is now officially configured to use:

- GCC as the compiler
- CMake as the build system
- Ninja as the build backend

## Changes

- Updated `README.md` with build instructions
- Updated team workflow documentation
- Updated CI to use Ninja generator
- Added warning in CMake if Ninja is not used

## Motivation

Previously, different developers could use different CMake generators (e.g. NMake, Visual Studio, MinGW), which could lead to inconsistencies and integration issues.

This change ensures:

- consistent build behavior across all machines
- easier onboarding
- more reliable CI

## Validation

- Local build tested using:
  - `cmake -S . -B build -G Ninja`
  - `cmake --build build`
- CI workflow updated accordingly

## Impact

- All team members must use Ninja for local builds
- Existing `build/` folders should be deleted and reconfigured

## Checklist

- [x] Build passes locally
- [x] Documentation updated
- [x] CI updated
- [x] No functional code impacted